### PR TITLE
Ensure we do not try to send data to null servers

### DIFF
--- a/supreme.js
+++ b/supreme.js
@@ -115,6 +115,13 @@ supreme.server = function server(primus, options) {
       local: true
     });
 
+    servers = servers.filter(function(server){
+      return server;
+    });
+    if (servers.length == 0){
+      var err = new Error("No servers availabls for sparks");
+      return fn(err, {ok: false, send: calls, local: false});
+    }
     async.mapLimit(servers, options.concurrently, function contact(server, next) {
       request({
         method: options.method,               // Set the correct method.

--- a/test/supreme.test.js
+++ b/test/supreme.test.js
@@ -172,6 +172,23 @@ describe('omega supreme', function () {
       });
     });
 
+    it('does not error when given an empty url', function (next) {
+      server.use('omega', omega);
+      server2.use('omega', omega);
+
+      var client = server2.Socket(http2.url);
+
+      client.id(function get(id) {
+        server.forward(null, 'foo', id, function (err, data) {
+          assume(err.message).to.equal('No servers availabls for sparks');
+          assume(data.send).to.equal(0);
+          assume(data.ok).to.be.false;
+          next();
+        });
+      });
+
+    });
+
     it('broadcasts if no spark id is provided', function (next) {
       server.use('omega', omega);
       server2.use('omega', omega);


### PR DESCRIPTION
Primus will crash if it get's a null server back.

An easy way to trigger this is with [omega-supreme](https://github.com/primus/omega-supreme) and [metroplex](https://github.com/primus/metroplex) :

``` javascript
primus.forward.spark("a-disconnected-spark-id", {some: "data"})
```

This can happen when two clients are sending messages directly to the other spark. Right now the server crashes. Michael Bay would say the server looks something like this:

![Server crash](http://how2becool.com/wp-content/uploads/2014/06/transformers_2_explosion_2.jpg)
