### PR TITLE
Adding the ability to alter the request url during runtime forwarding.

### DIFF
--- a/omega.js
+++ b/omega.js
@@ -40,7 +40,7 @@ module.exports = function omega(options) {
    */
   function intercept(req, res, next) {
     if (
-         !route.test(req.url)           // Incorrect URL.
+         !route.test(req.uri.pathname)  // Incorrect URL.
       || !req.headers.authorization     // Missing authorization.
       || options.method !== req.method  // Invalid method.
     ) return next();


### PR DESCRIPTION
We need the ability to alter the request URL during a ```forward``` message during run time. The use case we hit is that we are using Token based authentication where the token needs to be provided to the URL as ```?token=213132123123``` as a query parameter. I understand that you have the ```Authentication``` headers that I could provide, but this would require me to manage usernames and passwords between separate servers, which is a pain.  

With this change, I now have the ability to do the following...

```js
primus.forward(server, msg, sparkId, function(url) {
  url.query = {token: token};
  return url;
}, function(err, response) {
  // This would handle normal response.
});
```

This is also reverse compatible and does not alter the previous signature.