### PR TITLE
Add the `omega-supreme` middleware before the `authorization` middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,17 +27,17 @@
   },
   "homepage": "https://github.com/primus/omega-supreme",
   "dependencies": {
-    "async": "1.4.x",
-    "request": "2.63.x",
+    "async": "1.5.x",
+    "request": "2.65.x",
     "routable": "0.0.x"
   },
   "devDependencies": {
     "assume": "1.3.x",
     "binary-pack": "1.0.x",
-    "istanbul": "0.3.x",
+    "istanbul": "0.4.x",
     "mocha": "2.3.x",
     "pre-commit": "1.1.x",
-    "primus": "3.2.x",
+    "primus": "4.0.x",
     "ws": "0.8.x"
   }
 }

--- a/supreme.js
+++ b/supreme.js
@@ -41,12 +41,13 @@ supreme.options = function optional(options) {
  * @api public
  */
 supreme.server = function server(primus, options) {
+  var index = primus.indexOfLayer('authorization');
   options = supreme.options(options);
 
   //
   // Load the middleware so we can intercept messages.
   //
-  primus.before('omega-supreme', require('./omega')(options));
+  primus.before('omega-supreme', require('./omega'), options, index);
 
   /**
    * Forward a message to a given server set.

--- a/test.js
+++ b/test.js
@@ -76,9 +76,20 @@ describe('omega supreme', function () {
 
   describe('middleware', function () {
     it('adds a middleware layer', function () {
-      assume(!~primus.indexOfLayer('omega-supreme')).to.be.true();
+      assume(primus.indexOfLayer('omega-supreme')).equals(-1);
       primus.use('omega', omega);
-      assume(!!~primus.indexOfLayer('omega-supreme')).to.be.true();
+      assume(primus.indexOfLayer('omega-supreme')).is.above(-1);
+    });
+
+    it('adds the middleware layer before the authorization layer', function () {
+      var i, j;
+
+      assume(primus.indexOfLayer('authorization')).is.above(-1);
+
+      primus.use('omega', omega);
+      i = primus.indexOfLayer('omega-supreme');
+      j = primus.indexOfLayer('authorization');
+      assume(i).is.below(j);
     });
 
     it('does not handle invalid requests (wrong path)', function (next) {


### PR DESCRIPTION
This prevents the `authorization` middleware from blocking the `omega-supreme` requests.